### PR TITLE
Fix scenario deletion persistence

### DIFF
--- a/scenarios.html
+++ b/scenarios.html
@@ -696,7 +696,7 @@
             
             if (confirm('Are you sure you want to delete this scenario?')) {
                 delete app.projectData.scenarios[currentScenarioId];
-                app.saveProjects();
+                window.app.saveCurrentProject();
                 refreshScenarioList();
                 loadScenario('baseline');
             }


### PR DESCRIPTION
## Summary
- use CashflowApp.saveCurrentProject when deleting scenarios so persistence relies on the existing helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc36ac1b1c832b8d58badb3376648d