### PR TITLE
Persist scenario adjustment inputs

### DIFF
--- a/main.js
+++ b/main.js
@@ -199,7 +199,8 @@ class CashflowApp {
                     name: 'Baseline',
                     projections: {},
                     actuals: {},
-                    isLocked: false
+                    isLocked: false,
+                    adjustments: {}
                 }
             },
             currentScenario: 'baseline'
@@ -460,11 +461,19 @@ class CashflowApp {
     async loadCurrentProject() {
         console.log('Loading current project data...');
         try {
+            if (this.projectData?.scenarios) {
+                Object.values(this.projectData.scenarios).forEach(scenario => {
+                    if (scenario && typeof scenario === 'object' && !scenario.adjustments) {
+                        scenario.adjustments = {};
+                    }
+                });
+            }
+
             this.renderBudgetTable();
             this.updateProjectSummary();
             this.updateProjectInfo();
             this.loadScenarios();
-            
+
             console.log('Current project loaded');
         } catch (error) {
             console.error('Error loading current project:', error);
@@ -721,6 +730,9 @@ class CashflowApp {
                 if (!scenario.projections[categoryId]) {
                     scenario.projections[categoryId] = {};
                 }
+                if (scenario.adjustments && scenario.adjustments[categoryId] === undefined) {
+                    scenario.adjustments[categoryId] = category.amount;
+                }
 
                 const projections = this.calculations.calculateDistribution(
                     category.amount,
@@ -807,7 +819,8 @@ class CashflowApp {
                 name: name,
                 projections: JSON.parse(JSON.stringify(baseScenario.projections)),
                 actuals: JSON.parse(JSON.stringify(baseScenario.actuals)),
-                isLocked: false
+                isLocked: false,
+                adjustments: JSON.parse(JSON.stringify(baseScenario.adjustments || {}))
             };
             
             this.debouncedSave();

--- a/scenarios.html
+++ b/scenarios.html
@@ -756,6 +756,7 @@
 
             // Update comparison selector
             updateComparisonSelector();
+            updateComparison();
         }
 
         function loadBudgetAdjustments() {
@@ -765,20 +766,91 @@
 
             container.innerHTML = '';
 
+            const scenario = appInstance.projectData.scenarios[currentScenarioId];
+            if (scenario && !scenario.adjustments) {
+                scenario.adjustments = {};
+            }
+
             appInstance.projectData.budgetCategories.forEach(category => {
+                const scenarioAmount = scenario?.adjustments?.[category.id] ?? category.amount;
                 const adjustmentItem = document.createElement('div');
                 adjustmentItem.className = 'adjustment-item';
                 adjustmentItem.innerHTML = `
                     <div class="category-name">${category.name}</div>
-                    <input type="number" 
-                           class="adjustment-input" 
+                    <input type="number"
+                           class="adjustment-input"
                            data-category-id="${category.id}"
-                           value="${category.amount}"
+                           value="${scenarioAmount}"
                            step="0.01">
-                    <span>$${category.amount.toLocaleString()}</span>
+                    <span class="adjustment-display">$${formatCurrency(scenarioAmount)}</span>
                 `;
                 container.appendChild(adjustmentItem);
+
+                const input = adjustmentItem.querySelector('.adjustment-input');
+                attachAdjustmentListeners(input);
             });
+        }
+
+        function attachAdjustmentListeners(input) {
+            if (!input) return;
+            ['input', 'change'].forEach(eventName => {
+                input.addEventListener(eventName, handleAdjustmentChange);
+            });
+        }
+
+        function handleAdjustmentChange(event) {
+            const input = event.target;
+            const categoryId = parseInt(input.dataset.categoryId, 10);
+            const appInstance = window.app;
+            if (!appInstance || Number.isNaN(categoryId)) {
+                return;
+            }
+
+            const scenario = appInstance.projectData.scenarios[currentScenarioId];
+            if (!scenario) {
+                return;
+            }
+
+            if (!scenario.adjustments) {
+                scenario.adjustments = {};
+            }
+            if (!scenario.projections) {
+                scenario.projections = {};
+            }
+
+            const rawValue = parseFloat(input.value);
+            const newAmount = Number.isFinite(rawValue) ? rawValue : 0;
+            scenario.adjustments[categoryId] = newAmount;
+
+            const category = appInstance.projectData.budgetCategories.find(cat => cat.id === categoryId);
+            if (category) {
+                const projections = appInstance.calculations.calculateDistribution(
+                    newAmount,
+                    category.distributionMethod,
+                    category.distributionParams,
+                    24
+                );
+                scenario.projections[categoryId] = projections;
+            }
+
+            const displayEl = input.parentElement.querySelector('.adjustment-display');
+            if (displayEl) {
+                displayEl.textContent = `$${formatCurrency(newAmount)}`;
+            }
+
+            if (typeof appInstance.debouncedSave === 'function') {
+                appInstance.debouncedSave();
+            } else if (typeof appInstance.saveCurrentProject === 'function') {
+                appInstance.saveCurrentProject();
+            }
+
+            updateScenarioChart();
+            updateComparison();
+        }
+
+        function formatCurrency(value) {
+            const amount = Number.isFinite(value) ? value : 0;
+            return amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
         }
 
         function refreshScenarioList() {
@@ -845,16 +917,16 @@
             if (!tbody) return;
 
             tbody.innerHTML = '';
-            
+
             let totalCurrent = 0;
             let totalCompare = 0;
-            
+
             appInstance.projectData.budgetCategories.forEach(category => {
-                const currentAmount = category.amount;
-                const compareAmount = category.amount;
+                const currentAmount = currentScenario.adjustments?.[category.id] ?? category.amount;
+                const compareAmount = compareScenario.adjustments?.[category.id] ?? category.amount;
                 const variance = compareAmount - currentAmount;
                 const variancePercent = currentAmount > 0 ? (variance / currentAmount * 100).toFixed(1) : 0;
-                
+
                 totalCurrent += currentAmount;
                 totalCompare += compareAmount;
                 


### PR DESCRIPTION
## Summary
- store per-category adjustment values with each scenario so changes persist across reloads and copies
- recalculate projections and refresh the scenario comparison/chart when adjustment inputs change
- update the comparison table to read scenario-specific adjustment totals

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc3c2914e4832b8167e4e391cc45f4