### PR TITLE
Make scenario deletion await project save

### DIFF
--- a/scenarios.html
+++ b/scenarios.html
@@ -689,7 +689,7 @@
             }
         }
 
-        function deleteScenario() {
+        async function deleteScenario() {
             if (currentScenarioId === 'baseline') {
                 alert('Cannot delete baseline scenario');
                 return;
@@ -699,7 +699,7 @@
 
             if (confirm('Are you sure you want to delete this scenario?')) {
                 delete appInstance.projectData.scenarios[currentScenarioId];
-                appInstance.saveProjects();
+                await appInstance.saveCurrentProject();
                 refreshScenarioList();
                 loadScenario('baseline');
             }


### PR DESCRIPTION
## Summary
- make scenario deletion async so the removal waits for persistence to finish
- switch the scenario deletion path to call saveCurrentProject before refreshing the UI

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dc45ac0830832bb32aab78640fa923