### PR TITLE
Normalize persisted system settings on load

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -688,31 +688,48 @@
         // ============================================================================
         let autosaveTimerId = null;
 
-        function getStoredSystemSettings() {
-            const defaultSettings = {
-                defaultMethod: 's-curve',
-                currencyFormat: 'USD',
-                numberFormat: '1,234.56',
-                dateFormat: 'MM/DD/YYYY',
-                defaultIntensity: '3',
-                autosaveInterval: '5',
-                enableNotifications: false,
-                darkMode: false,
-                enableAutosave: false
-            };
+        const SYSTEM_SETTINGS_DEFAULTS = Object.freeze({
+            defaultMethod: 's-curve',
+            currencyFormat: 'USD',
+            numberFormat: '1,234.56',
+            dateFormat: 'MM/DD/YYYY',
+            defaultIntensity: '3',
+            autosaveInterval: '5',
+            enableNotifications: false,
+            darkMode: false,
+            enableAutosave: false
+        });
+
+        function cloneSystemDefaults() {
+            return { ...SYSTEM_SETTINGS_DEFAULTS };
+        }
+
+        function parseStoredSystemSettings() {
+            const defaults = cloneSystemDefaults();
+            const rawValue = localStorage.getItem('cashflow_settings');
+
+            if (!rawValue) {
+                return { settings: defaults, rawValue: null, error: null };
+            }
 
             try {
-                const stored = localStorage.getItem('cashflow_settings');
-                if (!stored) {
-                    return { ...defaultSettings };
+                const parsed = JSON.parse(rawValue);
+                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                    return { settings: { ...defaults, ...parsed }, rawValue, error: null };
                 }
 
-                const parsed = JSON.parse(stored);
-                return { ...defaultSettings, ...parsed };
+                return {
+                    settings: defaults,
+                    rawValue,
+                    error: new Error('Stored settings are not an object')
+                };
             } catch (error) {
-                console.warn('Unable to parse stored settings, falling back to defaults.', error);
-                return { ...defaultSettings };
+                return { settings: defaults, rawValue, error };
             }
+        }
+
+        function getStoredSystemSettings() {
+            return parseStoredSystemSettings().settings;
         }
 
         function updateAutoSaveTimer() {
@@ -721,7 +738,9 @@
                 autosaveTimerId = null;
             }
 
-            const settings = getStoredSystemSettings();
+            const settings = (window.app && window.app.systemSettings)
+                ? window.app.systemSettings
+                : getStoredSystemSettings();
 
             if (!settings.enableAutosave) {
                 return;
@@ -801,7 +820,7 @@
             document.getElementById('project-location').value = projectInfo.location || '';
             document.getElementById('project-manager').value = projectInfo.manager || '';
             document.getElementById('project-description').value = projectInfo.description || '';
-            
+
             const startDateInput = document.getElementById('start-date');
             const endDateInput = document.getElementById('end-date');
 
@@ -840,7 +859,41 @@
                 logoPreview.classList.add('has-logo');
             }
 
-            const systemSettings = getStoredSystemSettings();
+            const { settings: parsedSettings, error: settingsError } = parseStoredSystemSettings();
+            const defaults = typeof appInstance.getSystemSettingsDefaults === 'function'
+                ? appInstance.getSystemSettingsDefaults()
+                : cloneSystemDefaults();
+
+            const normalizedSettings = { ...defaults, ...parsedSettings };
+
+            const validMethods = ['s-curve', 'straight-line', 'manual'];
+            if (!validMethods.includes(normalizedSettings.defaultMethod)) {
+                normalizedSettings.defaultMethod = defaults.defaultMethod;
+            }
+
+            const intensityValue = parseInt(normalizedSettings.defaultIntensity, 10);
+            normalizedSettings.defaultIntensity = Number.isFinite(intensityValue)
+                ? String(Math.min(Math.max(intensityValue, 1), 5))
+                : defaults.defaultIntensity;
+
+            const autosaveIntervalNumber = parseFloat(normalizedSettings.autosaveInterval);
+            normalizedSettings.autosaveInterval = Number.isFinite(autosaveIntervalNumber) && autosaveIntervalNumber > 0
+                ? String(normalizedSettings.autosaveInterval)
+                : defaults.autosaveInterval;
+
+            normalizedSettings.currencyFormat = normalizedSettings.currencyFormat || defaults.currencyFormat;
+            normalizedSettings.numberFormat = normalizedSettings.numberFormat || defaults.numberFormat;
+            normalizedSettings.dateFormat = normalizedSettings.dateFormat || defaults.dateFormat;
+            normalizedSettings.enableAutosave = !!normalizedSettings.enableAutosave;
+            normalizedSettings.enableNotifications = !!normalizedSettings.enableNotifications;
+            normalizedSettings.darkMode = !!normalizedSettings.darkMode;
+
+            if (settingsError) {
+                console.warn('Unable to parse stored settings, falling back to defaults.', settingsError);
+                if (typeof showNotification === 'function') {
+                    showNotification('Stored system settings were corrupted. Defaults restored.', 'warning');
+                }
+            }
 
             const defaultMethodInput = document.getElementById('default-method');
             const currencyFormatInput = document.getElementById('currency-format');
@@ -852,15 +905,28 @@
             const notificationsInput = document.getElementById('enable-notifications');
             const darkModeInput = document.getElementById('dark-mode');
 
-            if (defaultMethodInput) defaultMethodInput.value = systemSettings.defaultMethod;
-            if (currencyFormatInput) currencyFormatInput.value = systemSettings.currencyFormat;
-            if (numberFormatInput) numberFormatInput.value = systemSettings.numberFormat;
-            if (dateFormatInput) dateFormatInput.value = systemSettings.dateFormat;
-            if (intensityInput) intensityInput.value = systemSettings.defaultIntensity;
-            if (autosaveIntervalInput) autosaveIntervalInput.value = systemSettings.autosaveInterval;
-            if (enableAutosaveInput) enableAutosaveInput.checked = !!systemSettings.enableAutosave;
-            if (notificationsInput) notificationsInput.checked = !!systemSettings.enableNotifications;
-            if (darkModeInput) darkModeInput.checked = !!systemSettings.darkMode;
+            if (defaultMethodInput) defaultMethodInput.value = normalizedSettings.defaultMethod;
+            if (currencyFormatInput) currencyFormatInput.value = normalizedSettings.currencyFormat;
+            if (numberFormatInput) numberFormatInput.value = normalizedSettings.numberFormat;
+            if (dateFormatInput) dateFormatInput.value = normalizedSettings.dateFormat;
+            if (intensityInput) intensityInput.value = normalizedSettings.defaultIntensity;
+            if (autosaveIntervalInput) autosaveIntervalInput.value = normalizedSettings.autosaveInterval;
+            if (enableAutosaveInput) enableAutosaveInput.checked = normalizedSettings.enableAutosave;
+            if (notificationsInput) notificationsInput.checked = normalizedSettings.enableNotifications;
+            if (darkModeInput) darkModeInput.checked = normalizedSettings.darkMode;
+
+            if (typeof appInstance.applySystemSettings === 'function') {
+                appInstance.applySystemSettings(normalizedSettings);
+            } else {
+                appInstance.systemSettings = normalizedSettings;
+                if (normalizedSettings.darkMode) {
+                    document.documentElement.classList.add('theme-dark');
+                    document.body.classList.add('theme-dark');
+                } else {
+                    document.documentElement.classList.remove('theme-dark');
+                    document.body.classList.remove('theme-dark');
+                }
+            }
         }
 
         function saveProjectInfo() {
@@ -950,6 +1016,9 @@
             };
 
             localStorage.setItem('cashflow_settings', JSON.stringify(settings));
+            if (typeof window.app.applySystemSettings === 'function') {
+                window.app.applySystemSettings(settings);
+            }
             updateAutoSaveTimer();
             showNotification('System settings saved successfully', 'success');
         }

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,49 @@
     --font-heading: 'Montserrat', 'Poppins', sans-serif;
 }
 
+:root.theme-dark {
+    --primary-color: #E5E7EB;
+    --secondary-color: #60A5FA;
+    --accent-color: #FBBF24;
+    --success-color: #34D399;
+    --warning-color: #FBBF24;
+    --error-color: #F87171;
+    --light-gray: #1F2937;
+    --medium-gray: #9CA3AF;
+    --dark-gray: #F3F4F6;
+}
+
+body.theme-dark,
+:root.theme-dark body {
+    background: #111827;
+    color: var(--dark-gray);
+}
+
+:root.theme-dark .panel,
+body.theme-dark .panel {
+    background: #1F2937;
+    color: var(--dark-gray);
+    border-color: rgba(148, 163, 184, 0.4);
+    box-shadow: 0 8px 30px rgba(15, 23, 42, 0.5);
+}
+
+:root.theme-dark .header,
+body.theme-dark .header {
+    background: rgba(17, 24, 39, 0.9);
+    border-bottom-color: var(--secondary-color);
+}
+
+:root.theme-dark .nav-tab,
+body.theme-dark .nav-tab {
+    color: var(--dark-gray);
+}
+
+:root.theme-dark .nav-tab.active,
+body.theme-dark .nav-tab.active {
+    background: var(--secondary-color);
+    color: #0B1120;
+}
+
 /* ============================================================================
    BASE & LAYOUT
    ============================================================================ */


### PR DESCRIPTION
## Summary
- parse persisted system settings with robust defaults and surface warnings when corrupted data is detected
- synchronize normalized preferences with the running app so theme toggles and default projection choices apply immediately
- add dark theme styling so the saved appearance preference has a visible effect across panels and navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc7be36814832bb8dc4a631e857b8d